### PR TITLE
Updates routes, cors, and controller for Anime resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
 end
 
 group :development do
@@ -38,4 +38,4 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.2)
@@ -152,6 +153,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pg (~> 1.2.3)
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.1)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/animes_controller.rb
+++ b/app/controllers/animes_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AnimesController < ApplicationController
+  def index
+    @animes = Anime.all
+
+    render json: @animes
+  end
+
+  def show
+    @anime = Anime.find(params[:id])
+
+    render json: @anime
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::API
 end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# Class for instantiating new Anime instances
 class Anime < ApplicationRecord
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,6 +11,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: %i[get post put patch delete options head]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :animes, only: %i[index show]
 end

--- a/db/migrate/20200807004819_add_validations_to_animes.rb
+++ b/db/migrate/20200807004819_add_validations_to_animes.rb
@@ -1,0 +1,12 @@
+class AddValidationsToAnimes < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :animes, :title, false
+    change_column_null :animes, :url, false
+    change_column_null :animes, :episodes, false
+    change_column_null :animes, :status, false
+    change_column_null :animes, :airing, false
+    change_column_null :animes, :score, false
+    change_column_null :animes, :synopsis, false
+    change_column_null :animes, :background, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_06_033047) do
+ActiveRecord::Schema.define(version: 2020_08_07_004819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "animes", force: :cascade do |t|
-    t.string "title"
-    t.string "url"
-    t.integer "episodes"
-    t.string "status"
-    t.boolean "airing"
-    t.float "score"
-    t.text "synopsis"
-    t.text "background"
+    t.string "title", null: false
+    t.string "url", null: false
+    t.integer "episodes", null: false
+    t.string "status", null: false
+    t.boolean "airing", null: false
+    t.float "score", null: false
+    t.text "synopsis", null: false
+    t.text "background", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #
@@ -5,3 +7,80 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Anime.create(
+  title: 'Test 1',
+  url: 'test.com',
+  episodes: 69,
+  status: 'Completed',
+  airing: false,
+  score: 6.9,
+  synopsis: 'Lorem dipshit',
+  background: 'Ippsum cookies'
+)
+
+Anime.create(
+  title: 'Test 2',
+  url: 'test.com',
+  episodes: 16,
+  status: 'Completed',
+  airing: false,
+  score: 8.3,
+  synopsis: 'K',
+  background: 'Naisu'
+)
+
+Anime.create(
+  title: 'Test 3',
+  url: 'test.com',
+  episodes: 48,
+  status: 'Completed',
+  airing: false,
+  score: 10,
+  synopsis: 'I already ran out of ideas for this.',
+  background: 'Not that I had any to begin with.'
+)
+
+Anime.create(
+  title: 'Test 4',
+  url: 'test.com',
+  episodes: 12,
+  status: 'Completed',
+  airing: false,
+  score: 3.7,
+  synopsis: 'Show sucks.',
+  background: 'Some schooldays shit, man.'
+)
+
+Anime.create(
+  title: 'Test 5',
+  url: 'test.com',
+  episodes: 24,
+  status: 'Completed',
+  airing: false,
+  score: 8,
+  synopsis: 'There is a hungry dude or something',
+  background: 'Dimsum?'
+)
+
+Anime.create(
+  title: 'Test 6',
+  url: 'test.com',
+  episodes: 12,
+  status: 'Completed',
+  airing: false,
+  score: 5,
+  synopsis: 'Lorem',
+  background: 'Ippsum'
+)
+
+Anime.create(
+  title: 'Test 7',
+  url: 'test.com',
+  episodes: 4,
+  status: 'Airing',
+  airing: true,
+  score: 6.9,
+  synopsis: 'Watch it to find out',
+  background: 'Idk your desktop background, sorry.'
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Anime.destroy_all
 
 Anime.create(
   title: 'Test 1',

--- a/test/controllers/animes_controller_test.rb
+++ b/test/controllers/animes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AnimesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/animes_controller_test.rb
+++ b/test/controllers/animes_controller_test.rb
@@ -1,7 +1,15 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AnimesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'should get index' do
+    get animes_url
+    assert_response :success
+  end
+
+  test 'should show anime' do
+    get animes_url(Anime.first)
+    assert_response :success
+  end
 end

--- a/test/fixtures/animes.yml
+++ b/test/fixtures/animes.yml
@@ -4,8 +4,26 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+one: {
+  title: 'Test 1',
+  url: 'test.com',
+  episodes: 69,
+  status: 'Completed',
+  airing: false,
+  score: 6.9,
+  synopsis: 'Lorem dipshit',
+  background: 'Ippsum cookies'
+}
 # column: value
 #
-two: {}
+two: {
+  title: 'Test 2',
+  url: 'test.com',
+  episodes: 16,
+  status: 'Completed',
+  airing: false,
+  score: 8.3,
+  synopsis: 'K',
+  background: 'Naisu'
+}
 # column: value


### PR DESCRIPTION
This PR includes the following changes:
- cors has been configured to accept requests from any resources
- The cors Gem has been uncommented in the Gemfile
- There is now seeded anime data to use for testing
- The index and show routes have been opened for the Anime controller

Tests coming soon.