### PR TITLE
Sets up model and controller for Mangas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,8 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem 'rack-cors'
+
+gem "rack-cors", ">= 1.0.4"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,8 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
-    rack-cors (1.0.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.2)
@@ -153,7 +154,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pg (~> 1.2.3)
   puma (~> 4.1)
-  rack-cors
+  rack-cors (>= 1.0.4)
   rails (~> 6.0.3, >= 6.0.3.1)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/mangas_controller.rb
+++ b/app/controllers/mangas_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class MangasController < ApplicationController
+  def index
+    @mangas = Manga.all
+
+    render json: @mangas
+  end
+
+  def show
+    @manga = Manga.find(params[:id])
+
+    render json: @manga
+  end
+end

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -1,0 +1,2 @@
+class Manga < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 
 Rails.application.routes.draw do
   resources :animes, only: %i[index show]
+  resources :mangas, only: %i[index show]
 end

--- a/db/migrate/20200816135059_create_mangas.rb
+++ b/db/migrate/20200816135059_create_mangas.rb
@@ -1,0 +1,8 @@
+class CreateMangas < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mangas do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200816135059_create_mangas.rb
+++ b/db/migrate/20200816135059_create_mangas.rb
@@ -1,6 +1,15 @@
 class CreateMangas < ActiveRecord::Migration[6.0]
   def change
     create_table :mangas do |t|
+      t.string :title, null: false
+      t.string :url, null: false
+      t.integer :volumes, null: false
+      t.integer :chapters, null: false
+      t.string :status, null: false
+      t.boolean :publishing, null: false
+      t.float :score, null: false
+      t.text :synopsis, null: false
+      t.text :background, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_07_004819) do
+ActiveRecord::Schema.define(version: 2020_08_16_135059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,20 @@ ActiveRecord::Schema.define(version: 2020_08_07_004819) do
     t.integer "episodes", null: false
     t.string "status", null: false
     t.boolean "airing", null: false
+    t.float "score", null: false
+    t.text "synopsis", null: false
+    t.text "background", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "mangas", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "url", null: false
+    t.integer "volumes", null: false
+    t.integer "chapters", null: false
+    t.string "status", null: false
+    t.boolean "publishing", null: false
     t.float "score", null: false
     t.text "synopsis", null: false
     t.text "background", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,3 +85,27 @@ Anime.create(
   synopsis: 'Watch it to find out',
   background: 'Idk your desktop background, sorry.'
 )
+
+Manga.create(
+  title: 'Test 1',
+  url: 'test.com',
+  volumes: 7,
+  chapters: 69,
+  status: 'Completed',
+  publishing: false,
+  score: 6.9,
+  synopsis: 'Lorem dipshit',
+  background: 'Ippsum cookies'
+)
+
+Manga.create(
+  title: 'Test 2',
+  url: 'test.com',
+  volumes: 1,
+  chapters: 13,
+  status: 'Completed',
+  publishing: false,
+  score: 6.9,
+  synopsis: 'Lorem dipshit',
+  background: 'Ippsum cookies'
+)

--- a/test/controllers/mangas_controller_test.rb
+++ b/test/controllers/mangas_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MangasControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/mangas_controller_test.rb
+++ b/test/controllers/mangas_controller_test.rb
@@ -1,7 +1,15 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class MangasControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'should get index' do
+    get mangas_url
+    assert_response :success
+  end
+
+  test 'should show anime' do
+    get mangas_url(Manga.first)
+    assert_response :success
+  end
 end

--- a/test/fixtures/mangas.yml
+++ b/test/fixtures/mangas.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/mangas.yml
+++ b/test/fixtures/mangas.yml
@@ -4,8 +4,26 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one: {
+  title: 'Test 1',
+  url: 'test.com',
+  volumes: 7,
+  chapters: 69,
+  status: 'Completed',
+  publishing: false,
+  score: 6.9,
+  synopsis: 'Lorem dipshit',
+  background: 'Ippsum cookies'
+}
+
+two: {
+  title: 'Test 2',
+  url: 'test.com',
+  volumes: 1,
+  chapters: 16,
+  status: 'Completed',
+  publishing: false,
+  score: 8.3,
+  synopsis: 'K',
+  background: 'Naisu'
+}

--- a/test/models/manga_test.rb
+++ b/test/models/manga_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MangaTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Previously there was no controller or model for the manga portion
of this app. This commit instantiates the Manga model as well as
the controller. The controller currently only has two actions:
`index`, for showing all mangas, and `show`, for display a particular
manga instance.

Furthermore, this commit exposes the index and show routes so that
information may be fetched via GET request.